### PR TITLE
UPDATE: modernize pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.4.0
+  rev: v4.5.0
   hooks:
   - id: end-of-file-fixer
   - id: mixed-line-ending
@@ -8,19 +8,19 @@ repos:
   - id: check-yaml
   - id: check-toml
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.8.0
+  rev: v1.10.0
   hooks:
   - id: python-check-blanket-noqa
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.6.4
+  rev: 5.13.2
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: 20.8b1
+  rev: 24.2.0
   hooks:
   - id: black
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.4
+- repo: https://github.com/PyCQA/flake8
+  rev: 3.9.2
   hooks:
   - id: flake8
     additional_dependencies:


### PR DESCRIPTION
Fixes #18 

Initial changes:

- switch flake8 repository entry from GitLab (now missing) to GitHub;
- applies `pre-commit autoupdate`
- backs-off flake8 version from 0.7.0 to 3.9.2 for dependency compatibility.

The `additional_dependencies` section may benefit from being updated, this will have to be accomplished manually.