### PR TITLE
🔧 MAINTAIN: Resolve CI Failures; Drop Python 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,25 +13,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.7
-    - uses: pre-commit/action@v2.0.0
+        python-version: 3.11
+    - uses: pre-commit/action@v3.0.0
 
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.11]
         os: [ubuntu-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -39,21 +39,22 @@ jobs:
       # we install with flit --pth-file,
       # so that coverage will be recorded up for the module
       run: |
-        pip install flit
+        pip install flit~=3.0
         flit install --deps=production --extras=test --pth-file
 
     - name: Run pytest
       run: |
         pytest --cov=mdformat_tables --cov-report=xml --cov-report=term-missing
 
-    - name: Upload to Codecov
-      if: matrix.python-version == 3.7
-      uses: codecov/codecov-action@v1
-      with:
-        name: pytests-py3.7
-        flags: pytests
-        file: ./coverage.xml
-        fail_ci_if_error: true
+    # FYI: Requires token to continue usage
+    # - name: Upload to Codecov
+    #   if: matrix.python-version == 3.7
+    #   uses: codecov/codecov-action@v1
+    #   with:
+    #     name: pytests-py3.7
+    #     flags: pytests
+    #     file: ./coverage.xml
+    #     fail_ci_if_error: true
 
   pre-commit-hook:
     runs-on: ubuntu-latest
@@ -81,9 +82,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.7
     - name: install flit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,10 @@ repos:
   hooks:
   - id: black
 - repo: https://github.com/PyCQA/flake8
-  rev: 3.9.2
+  rev: 7.0.0
   hooks:
   - id: flake8
     additional_dependencies:
-    - flake8-bugbear==20.11.1
-    - flake8-builtins==1.5.3
-    - flake8-comprehensions==3.3.1
+    - flake8-bugbear>=20.11.1
+    - flake8-builtins>=1.5.3
+    - flake8-comprehensions>=3.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 keywords = "mdformat,markdown,markdown-it"
 
-requires-python=">=3.6.1"
+requires-python=">=3.7.0"
 requires=["mdformat>=0.7.5,<0.8.0"]
 
 [tool.flit.metadata.requires-extra]

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
-envlist = py{36,37,38,39}
+envlist = py{37,311},py{37,311}-hook
 isolated_build = True
 
-[testenv:py{36,37,38,39}]
+[testenv:py{37,311}]
 extras = test
-commands = pytest --cov={envsitepackagesdir}/mdformat_tables {posargs}
+commands = pytest --cov={envsitepackagesdir}/mdformat_tables {posargs} --ff --nf -vv
 
-[testenv:py{36,37,38,39}-pre-commit]
+[testenv:pre-commit]
 deps = pre-commit
 commands = pre-commit run {posargs}
 
-[testenv:py{36,37,38,39}-hook]
+[testenv:py{37,311}-hook]
 deps = pre-commit
 commands = pre-commit run --config .pre-commit-test.yaml {posargs:--all-files --verbose --show-diff-on-failure}
 


### PR DESCRIPTION
Split from #17

Note: drops support for Python 3.6